### PR TITLE
Add iPad Pro icon size.

### DIFF
--- a/AEIconizer.sketchplugin/Contents/Sketch/AEIconizer.cocoascript
+++ b/AEIconizer.sketchplugin/Contents/Sketch/AEIconizer.cocoascript
@@ -3,7 +3,10 @@
 // Version: 1.0
 
 // iOS icon sizes
-var iconSizes = [NSArray arrayWithObjects: 512, 76, 60, 40, 29, nil];
+var iconSizes = [NSArray arrayWithObjects: 512, 83.5, 76, 60, 40, 29, nil];
+
+// iOS icon names
+var artboardNames = [NSArray arrayWithObjects:"Icon-29", "Icon-29@2x", "Icon-29@3x", "Icon-40", "Icon-40@2x", "Icon-40@3x", "Icon-60", "Icon-60@2x", "Icon-60@3x", "Icon-76", "Icon-76@2x", "Icon-76@3x", "Icon-83.5", "Icon-83.5@2x", "Icon-83.5@3x", "iTunesArtwork-512", "iTunesArtwork-512@2x" , nil];
 
 // do stuff
 function onRun(context) {
@@ -53,7 +56,6 @@ function removeExistingIcons(context) {
   var loop = [artboards objectEnumerator];
   while (artboard = [loop nextObject]) {
     var name = [artboard name];
-    var artboardNames = [NSArray arrayWithObjects:"Icon-29", "Icon-29@2x", "Icon-29@3x", "Icon-40", "Icon-40@2x", "Icon-40@3x", "Icon-60", "Icon-60@2x", "Icon-60@3x", "Icon-76", "Icon-76@2x", "Icon-76@3x", "iTunesArtwork-512", "iTunesArtwork-512@2x" , nil];
     if ([artboardNames containsObject: name]) {
       [[doc currentPage] removeLayer:artboard];
     }


### PR DESCRIPTION
Adds 83.5 as an icon size, creating the Icon-83.5@2x that is required for apps targeting the iPad Pro. Also adds new icon names to the icon name list so that the appropriate artboards are removed when the plugin runs.