### PR TITLE
Update AEIconizer.cocoascript

### DIFF
--- a/AEIconizer.sketchplugin/Contents/Sketch/AEIconizer.cocoascript
+++ b/AEIconizer.sketchplugin/Contents/Sketch/AEIconizer.cocoascript
@@ -3,7 +3,7 @@
 
 // iOS icon sizes
 var iTunesSizes = [NSArray arrayWithObjects: 512, nil];
-var iOSSizes = [NSArray arrayWithObjects: 83.5, 76, 60, 40, 29, nil];
+var iOSSizes = [NSArray arrayWithObjects: 83.5, 76, 72, 60, 50, 40, 29, nil];
 var watchOSSizes = [NSArray arrayWithObjects: 98, 86, 27.5, 24, nil];
 var wirelessInstallSizes = [NSArray arrayWithObjects: 57, nil];
 var iconSizes = [NSArray arrayWithObjects: iTunesSizes, iOSSizes, watchOSSizes, wirelessInstallSizes, nil];
@@ -14,8 +14,10 @@ var artboardNames = [NSArray arrayWithObjects:
     "Icon-27.5", "Icon-27.5@2x", "Icon-27.5@3x", 
     "Icon-29", "Icon-29@2x", "Icon-29@3x", 
     "Icon-40", "Icon-40@2x", "Icon-40@3x", 
+    "Icon-50", "Icon-50@2x", "Icon-50@3x", 
 	"Icon-57", "Icon-57@2x", "Icon-57@3x",
     "Icon-60", "Icon-60@2x", "Icon-60@3x", 
+    "Icon-72", "Icon-72@2x", "Icon-72@3x", 
     "Icon-76", "Icon-76@2x", "Icon-76@3x", 
     "Icon-83.5", "Icon-83.5@2x", "Icon-83.5@3x", 
     "Icon-86", "Icon-86@2x", "Icon-86@3x", 


### PR DESCRIPTION
Needed a few additional sizes that didn't seem to be included in the script. Here's the sizes I added:

- 72 for iPad iOS 5,6
- 50 for iPad Spotlight iOS 5,6
- 60 for iPhone 7-9
Added 72, 60, 50