### PR TITLE
Add size 44 to watchOS sizes

### DIFF
--- a/AEIconizer.sketchplugin/Contents/Sketch/AEIconizer.cocoascript
+++ b/AEIconizer.sketchplugin/Contents/Sketch/AEIconizer.cocoascript
@@ -3,7 +3,7 @@
 
 var iTunesSizes = NSArray.arrayWithArray([1024])
 var iOSSizes = NSArray.arrayWithArray([83.5, 76, 60, 40, 29, 20])
-var watchOSSizes = NSArray.arrayWithArray([98, 86, 44, 27.5, 24])
+var watchOSSizes = NSArray.arrayWithArray([108, 98, 86, 44, 27.5, 24])
 var otherSizes = NSArray.arrayWithArray([72, 57, 50])
 var macOSSizes = NSArray.arrayWithArray([256, 128, 32, 16])
 var iconSizes = NSArray.arrayWithArray([iTunesSizes, iOSSizes, watchOSSizes, otherSizes, macOSSizes])

--- a/AEIconizer.sketchplugin/Contents/Sketch/AEIconizer.cocoascript
+++ b/AEIconizer.sketchplugin/Contents/Sketch/AEIconizer.cocoascript
@@ -3,7 +3,7 @@
 
 var iTunesSizes = NSArray.arrayWithArray([1024])
 var iOSSizes = NSArray.arrayWithArray([83.5, 76, 60, 40, 29, 20])
-var watchOSSizes = NSArray.arrayWithArray([98, 86, 27.5, 24])
+var watchOSSizes = NSArray.arrayWithArray([98, 86, 44, 27.5, 24])
 var otherSizes = NSArray.arrayWithArray([72, 57, 50])
 var macOSSizes = NSArray.arrayWithArray([256, 128, 32, 16])
 var iconSizes = NSArray.arrayWithArray([iTunesSizes, iOSSizes, watchOSSizes, otherSizes, macOSSizes])


### PR DESCRIPTION
I started making an Apple Watch app today in Xcode 10, and it turns out that it wants an icon with the size 88x88 px.

<img width="575" alt="screenshot 2018-10-07 at 15 08 29" src="https://user-images.githubusercontent.com/923548/46582165-412eb600-ca43-11e8-9cf7-14774a9f293e.png">

Since this was such a simple fix I decided to do it using the web ui offered by GitHub. I hope it didn't do anything stupid :D