### PR TITLE
Add new watch icon sizes

### DIFF
--- a/AEIconizer.sketchplugin/Contents/Sketch/AEIconizer.cocoascript
+++ b/AEIconizer.sketchplugin/Contents/Sketch/AEIconizer.cocoascript
@@ -3,7 +3,7 @@
 
 var iTunesSizes = NSArray.arrayWithArray([1024])
 var iOSSizes = NSArray.arrayWithArray([83.5, 76, 60, 40, 29, 20])
-var watchOSSizes = NSArray.arrayWithArray([108, 98, 86, 44, 27.5, 24])
+var watchOSSizes = NSArray.arrayWithArray([117, 108, 98, 86, 51, 46, 44, 33, 27.5, 24])
 var otherSizes = NSArray.arrayWithArray([72, 57, 50])
 var macOSSizes = NSArray.arrayWithArray([256, 128, 32, 16])
 var iconSizes = NSArray.arrayWithArray([iTunesSizes, iOSSizes, watchOSSizes, otherSizes, macOSSizes])


### PR DESCRIPTION
Xcode 13 RC introduces a couple of new watchOS icon sizes. These changes add the new sizes.